### PR TITLE
fix: upgrade deprecated GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/Build_VIPM_Library.yml
+++ b/.github/workflows/Build_VIPM_Library.yml
@@ -45,10 +45,10 @@ jobs:
 
       # Get env variables
       # https://github.com/marketplace/actions/github-environment-variables-action
-      - uses: FranzDiebold/github-env-vars-action@v2.8.0
+      - uses: FranzDiebold/github-env-vars-action@v2.9.0
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: vipm-InstallPackage
         uses: NEVSTOP-LAB/vipm-InstallPackage@main

--- a/.github/workflows/CSharp_SDK.yml
+++ b/.github/workflows/CSharp_SDK.yml
@@ -32,10 +32,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up .NET 8 SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.0.x'
 
@@ -67,10 +67,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up .NET 8 SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.0.x'
 
@@ -106,7 +106,7 @@ jobs:
           path: nupkg
 
       - name: Set up .NET 8 SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.0.x'
 

--- a/.github/workflows/C_SDK.yml
+++ b/.github/workflows/C_SDK.yml
@@ -31,7 +31,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Configure (CMake)
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
@@ -51,7 +51,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Configure with ASan + UBSan
         run: |

--- a/.github/workflows/Check_Broken_VIs.yml
+++ b/.github/workflows/Check_Broken_VIs.yml
@@ -42,7 +42,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: vipm-InstallPackage
         uses: NEVSTOP-LAB/vipm-InstallPackage@main

--- a/.github/workflows/Python_SDK.yml
+++ b/.github/workflows/Python_SDK.yml
@@ -25,10 +25,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -53,10 +53,10 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -80,10 +80,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Changes

Upgrade GitHub Actions to eliminate Node.js 20 deprecation warning.

**CSharp_SDK.yml:** checkout@v4 -> @v7, setup-dotnet@v4 -> @v6
**Python_SDK.yml:** checkout@v4 -> @v7, setup-python@v5 -> @v7
**C_SDK.yml:** checkout@v4 -> @v7
**Check_Broken_VIs.yml:** checkout@v3 -> @v7
**Build_VIPM_Library.yml:** checkout@v4 -> @v7, env-vars@v2.8.0 -> @v2.9.0

All target versions use node24.